### PR TITLE
Initial commit

### DIFF
--- a/AdminInterface.coffee
+++ b/AdminInterface.coffee
@@ -1,0 +1,102 @@
+window.h = maquette.h
+
+class ZeroAdmin
+	constructor: (@title, @pages) ->
+		@tables = {}
+		@loadDB(0)
+
+	loadDB: (page_num) =>
+		table_keys = Object.keys(@pages)
+		Page.cmd "dbQuery", ["SELECT "+Object.keys(@pages[table_keys[page_num]][1]).toString()+" FROM "+table_keys[page_num]], (res) =>
+			if @pages[table_keys[page_num]][0].file? == false
+				@tables[table_keys[page_num]] = res
+			if table_keys[page_num + 1]?
+				@loadDB(page_num + 1)
+			else
+				Page.cmd "dbQuery", ["SELECT * FROM JSON"], (json_id_list) =>
+					@json_id_list = json_id_list
+					ZeroAdmin.projector.append(document.body, ZeroTalkAdmin.render)
+
+	render: =>
+		console.log "[ZeroAdmin] ", @tables
+		h("div.ZeroAdmin", [
+			h("div.aiLeft",
+				[h("div.aiPageTitle", {onclick: @updateDB},
+					["Update Database"]
+				)],
+				(h("div.aiPageTitle", {name: page_name, onclick: @pageOnClick, classes: {activePage: @activePage == page_name}},
+					[page[0].title]
+				) for page_name, page of @pages)
+			),
+			@renderActivePage() if @activePage?
+		])
+
+	renderActivePage: =>
+		h("div", {key: @activePage}, [
+			h("table.page", {table_name: @activePage},
+				[h("tr",
+					(h("td", [field_name]) for field_name of @pages[@activePage][1])
+				)],
+				(@renderRecord(record_num) for record, record_num in @tables[@activePage])
+			)
+		])
+
+	renderRecord: (record_num) =>
+		record = @tables[@activePage][record_num]
+		h("tr.record", {record_num: record_num.toString()},
+			(@renderField(field_name, record_num) for field_name of @pages[@activePage][1])
+		)
+
+	renderField: (field_name, record_num) =>
+		field = @tables[@activePage][record_num][field_name]
+		h("td.field", {field_name: field_name}, [
+			if @pages[@activePage][1][field_name][0] == "textarea"
+				h("textarea", {oninput: @onInput}, [field])
+			else
+				h("input.text", {value: field, oninput: @onInput})
+		])
+
+	onInput: (evt) =>
+		field_name = $(evt.target).parent().attr("field_name")
+		record_num = $(evt.target).parent().parent().attr("record_num")
+		table_name = $(evt.target).parent().parent().parent().attr("table_name")
+		@tables[table_name][record_num][field_name] = $(evt.target).val()
+
+	updateDB: =>
+		for json_id in (id.json_id for id in @json_id_list when id.file_name == "data.json")
+			user = @json_id_list.find((id) => id.json_id == json_id).directory
+			@updateUserRecords(user, json_id)
+
+	updateUserRecords: (user, json_id) =>
+		inner_path = "data/users/#{user}/data.json"
+		Page.cmd "fileGet", {"inner_path": inner_path, "required": false}, (data) =>
+			data = JSON.parse(data)
+			for table_name, table of @tables
+				console.log table_name, data[table_name]
+				if @pages[table_name][0].parent?
+					for child_name, child of data[table_name]
+						for user_record, user_record_num in child
+							record = table.find((record) => record.added == user_record.added and record.json_id == json_id)
+							console.log record	
+							for field_name of user_record when record[field_name]?
+								data[table_name][child_name][user_record_num][field_name] = record[field_name]
+				else
+					for user_record, user_record_num in data[table_name]
+						record = table.find((record) => record.added == user_record.added and record.json_id == json_id)
+						console.log record	
+						for field_name of user_record when record[field_name]?
+							data[table_name][user_record_num][field_name] = record[field_name]
+			Page.cmd "fileWrite", [inner_path, btoa(JSON.stringify(data))]
+
+	pageOnClick: (evt) =>
+		console.log "[ZeroAdmin] ", $(evt.target).attr("name")
+		@activePage = $(evt.target).attr("name")
+		
+	@projector: maquette.createProjector(),
+	@page: (attr, cont) -> [attr, cont],
+	@user: (attr) -> ["user", attr],
+	@input: (attr) -> ["input", attr],
+	@textarea: (attr) -> ["textarea", attr],
+	@select: (attr) -> ["select", attr]
+
+window.ZeroAdmin = ZeroAdmin

--- a/AdminInterfaceStyles.coffee
+++ b/AdminInterfaceStyles.coffee
@@ -1,0 +1,70 @@
+$("body").append("""
+<style>
+.ZeroAdmin {
+	padding: 10px;
+	padding-left: 210px;
+	background: white; 
+	position: fixed; 
+	top: 0px; 
+	left: 0px; 
+	bottom: 0px; 
+	right: 0px; 
+	overflow: auto;
+}
+
+.hidden {
+    display: none;
+}
+
+.aiLeft {
+	position: fixed;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	width: 200px;
+	margin: 0px !important;
+	padding: 0px;
+	background-color: #212121;
+	-webkit-box-shadow: rgba(0, 0, 0, 0.156863) 0px 3px 10px, rgba(0, 0, 0, 0.227451) 0px 3px 10px;
+	-moz-box-shadow: rgba(0, 0, 0, 0.156863) 0px 3px 10px, rgba(0, 0, 0, 0.227451) 0px 3px 10px;
+	box-shadow: rgba(0, 0, 0, 0.156863) 0px 3px 10px, rgba(0, 0, 0, 0.227451) 0px 3px 10px;
+}
+
+.aiPageTitle {
+	border: none;
+	color: #FAFAFA !important;
+	font-family: 'Roboto', sans-serif !important;
+	font-weight: normal;
+	display: block !important;
+	margin: 0px;
+	padding: 16px;
+	line-height: 100% !important;
+}
+
+.aiPageTitle:hover {
+    background-color: black;
+}
+
+table {
+	border-spacing: 1px;
+	font-family: Roboto, sans-serif;
+	color: #212121;
+	font-size: 12px;
+	background: #F5F5F5;
+	margin: 0px;
+}
+
+table tr {
+	text-align: center;
+}
+
+table tr td {
+	background: #FAFAFA;
+	padding: 3px;
+}
+
+table tr:hover td{
+	background: #F5F5F5;
+}
+</style>
+""")

--- a/Sample Configurations/ZeroTalkAdmin.coffee
+++ b/Sample Configurations/ZeroTalkAdmin.coffee
@@ -1,0 +1,21 @@
+window.ZeroTalkAdmin = new ZeroAdmin "ZeroTalkAdmin", {
+	"topic": ZeroAdmin.page({title:"Topics", orderby: "added DESC"}, {
+		"json_id": ZeroAdmin.user({title: "Username", disabled: 1, save: 0}),
+		"added": ZeroAdmin.input({formatter: Date.toDate, deformatter: Date.fromDate}),
+		"title": ZeroAdmin.input(),
+		"body": ZeroAdmin.textarea(),
+		"type": ZeroAdmin.select({values: ["", "group"]}),
+		"parent_topic_uri": ZeroAdmin.select({title: "Parent topic", values: ""})
+	}),
+	"comment": ZeroAdmin.page({title:"Comments", orderby: "added DESC", parent: "topic"}, {
+		"json_id": ZeroAdmin.user({title: "Username", disabled: 1, save: 0}),
+		"added": ZeroAdmin.input({formatter: Date.toDate, deformatter: Date.fromDate}),
+		"body": ZeroAdmin.textarea(),
+		"topic_uri": ZeroAdmin.select({title: "Topic", values: ""})
+	}), 
+	"settings": ZeroAdmin.page({title:"Settings", file: "content.json"}, {
+		"settings.admin": ZeroAdmin.input({title: "Admin name"}),
+		"settings.href": ZeroAdmin.input({title: "Admin contact url"}),
+		"settings.sticky_uris": ZeroAdmin.select({title: "Sticky topic uris", multi: 1, values: ""})
+	})
+}


### PR DESCRIPTION
Panel generates based on provided configuration. Can edit existing  database records (deletion, insertion not yet implemented). Input field formatting/deformatting not yet implemented.

JSON file editing for settings needs to be added.

For testing, can clone this http://127.0.0.1:43110/1DWD4M2dy6rDAF1dhxQE953hSWTib1ZEjo .

The panel currently gets painted on top of all existing pages, will need to be bound to a specific url.
